### PR TITLE
Added first initial support of Fedora

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ env:
   - distribution: centos
     init:        /usr/lib/systemd/systemd
     version:     7
-  # - distribution: fedora
-  #   init:      /usr/lib/systemd/systemd
-  #   version:   26
-  # - distribution: fedora
-  #   init:      /usr/lib/systemd/systemd
-  #   version:   25
-  # - distribution: fedora
-  #   init:      /usr/lib/systemd/systemd
-  #   version:   24
+  - distribution: fedora
+    init:      /usr/lib/systemd/systemd
+    version:   26
+  - distribution: fedora
+    init:      /usr/lib/systemd/systemd
+    version:   25
+  - distribution: fedora
+    init:      /usr/lib/systemd/systemd
+    version:   24
   - distribution: ubuntu
     init:        /lib/systemd/systemd
     version:     bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,12 @@ galaxy_info:
     versions:
     - 6
     - 7
+  - name: Fedora
+    versions:
+    - 23
+    - 24
+    - 25
+    - 26
   - name:              Ubuntu
     versions:
     - bionic

--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -15,7 +15,7 @@
   become: true
   when: >
         (ansible_os_family == "RedHat" and
-        ansible_distribution_release != "Fedora") and
+        ansible_distribution != "Fedora") and
         (ansible_distribution_version < '7')
 
 - name: configure_root_access | ensuring MySQL service is running
@@ -26,7 +26,7 @@
   become: true
   when: >
         ((ansible_os_family == "RedHat" and
-        ansible_distribution_release != "Fedora") and
+        ansible_distribution != "Fedora") and
         (ansible_distribution_version >= '7')) or
         ansible_os_family == "Alpine"
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -6,7 +6,7 @@
   become: true
   with_items:
     - MySQL-python
-  when: ansible_distribution_release != "Fedora"
+  when: ansible_distribution != "Fedora"
 
 - name: redhat | installing mysql CentOS 6
   yum:
@@ -17,18 +17,55 @@
     - mysql-server
     - mysql
   when: >
-        ansible_distribution_release != "Fedora" and
+        ansible_distribution != "Fedora" and
         (ansible_distribution_version < '7')
 
-- name: redhat | enabling on boot and start CentOS 6
+- name: redhat | Installing Pre-Reqs On Fedora
+  dnf:
+    name: "{{ item }}"
+    state: present
+  become: true
+  with_items:
+    - libselinux-python
+    - mysql-devel
+    - python-devel
+    - python-dnf
+  when: >
+        ansible_distribution == "Fedora"
+
+- name: redhat | Installing MySQL Fedora
+  dnf:
+    name: "{{ item }}"
+    state: present
+  become: true
+  with_items:
+    - mysql-server
+    - mysql
+  when: >
+        ansible_distribution == "Fedora"
+
+- name: redhat | Installing Python Modules For Fedora
+  pip:
+    name: "{{ item }}"
+    state: present
+  become: true
+  with_items:
+    - mysql-python
+  when: >
+        ansible_distribution == "Fedora"
+
+- name: redhat | Ensuring mysqld Is Enabled and Starts On Boot
   service:
-    name: "mysqld"
-    state: "started"
-    enabled: yes
+    name: mysqld
+    state: started
+    enabled: true
   become: true
   when: >
-        ansible_distribution_release != "Fedora" and
-        (ansible_distribution_version < '7')
+        (ansible_distribution == "CentOS" and
+        ansible_distribution_version < "7") or
+        (ansible_distribution == "Fedora" and
+        (ansible_distribution_version == "24" or
+        ansible_distribution_version == "25"))
 
 - name: redhat | installing mariadb mysql CentOS 7
   yum:
@@ -39,7 +76,7 @@
     - mariadb-server
     - mariadb
   when: >
-        ansible_distribution_release != "Fedora" and
+        ansible_distribution != "Fedora" and
         (ansible_distribution_version >= '7')
 
 - name: redhat | configuring mysql
@@ -53,15 +90,18 @@
   become: true
   notify: "restart mariadb"
   when: >
-        ansible_distribution_release != "Fedora" and
+        ansible_distribution != "Fedora" and
         (ansible_distribution_version >= '7')
 
-- name: redhat | enabling on boot and start CentOS 7
+- name: redhat | Ensuring mariadb Service Is Enabled and Starts On Boot
   service:
     name: "mariadb"
     state: "started"
     enabled: yes
   become: true
   when: >
-        ansible_distribution_release != "Fedora" and
-        (ansible_distribution_version >= '7')
+        (ansible_distribution == "CentOS" and
+        ansible_distribution_version >= '7') or
+        (ansible_distribution == "Fedora" and
+        (ansible_distribution_version <= "23" or
+        ansible_distribution_version >= "26"))


### PR DESCRIPTION
Fedora 26 and up is not supported yet as the install fails during Python
module install.